### PR TITLE
7.x islandora 2046: Allow Islandora Batch to be extended for more actions than just pure ingests

### DIFF
--- a/includes/ingest.batch.inc
+++ b/includes/ingest.batch.inc
@@ -425,7 +425,6 @@ function islandora_batch_process_results($results, $timeout, $lock_timeout, &$co
         $actionresult_object = $islandora_batch_object->batchRepositoryAction();
        
         if ($actionresult_object) {
-          $object['data'] = serialize($actionresult_object);
           $context['message'] = t('Successfully %action %pid.', 
             array(
               '%pid' => $actionresult_object->id,

--- a/includes/ingest.batch.inc
+++ b/includes/ingest.batch.inc
@@ -429,7 +429,7 @@ function islandora_batch_process_results($results, $timeout, $lock_timeout, &$co
           $context['message'] = t('Successfully %action %pid.', 
             array(
               '%pid' => $actionresult_object->id,
-              '%action' => $islandora_batch_object->getRepositoryActionDescription
+              '%action' => $islandora_batch_object->getRepositoryActionDescription()
             ));
 >>>>>>> First steps on abstract the repository action
         }
@@ -439,7 +439,7 @@ function islandora_batch_process_results($results, $timeout, $lock_timeout, &$co
           $context['message'] = t('Unknown error: Failed to %action %pid.', 
             array(
               '%pid' => $islandora_batch_object->id,
-              '%action' => $islandora_batch_object->getRepositoryActionDescription
+              '%action' => $islandora_batch_object->getRepositoryActionDescription()
             ));
         }
       }
@@ -449,7 +449,7 @@ function islandora_batch_process_results($results, $timeout, $lock_timeout, &$co
         $context['message'] = t('Exception occured: Failed to %action %pid because of %message.',
         array(
           '%pid' => $islandora_batch_object->id,
-          '%action' => $islandora_batch_object->getRepositoryActionDescription,
+          '%action' => $islandora_batch_object->getRepositoryActionDescription(),
           '%message' => $e->getMessage()
         ));
         

--- a/includes/ingest.batch.inc
+++ b/includes/ingest.batch.inc
@@ -416,46 +416,40 @@ function islandora_batch_process_results($results, $timeout, $lock_timeout, &$co
           $islandora_batch_object->repository->api->connection->password = $user->pass;
         }
 
-        // Push to backend.
-<<<<<<< HEAD
-        $ingested_object = islandora_add_object($ingest_object);
-        if ($ingested_object) {
-          $context['message'] = t('Ingested %pid.', array('%pid' => $ingested_object->id));
-=======
-        $actionresult_object = $islandora_batch_object->batchRepositoryAction();
+		// Push to backend.
+		        $actionresult_object = $islandora_batch_object->batchRepositoryAction();
        
-        if ($actionresult_object) {
-          $context['message'] = t('Successfully %action %pid.', 
-            array(
-              '%pid' => $actionresult_object->id,
-              '%action' => $islandora_batch_object->getRepositoryActionDescription()
-            ));
->>>>>>> First steps on abstract the repository action
-        }
-        else {
-          // Failed to process on backend...  Flag an error.
-          $object['state'] = ISLANDORA_BATCH_STATE__ERROR;
-          $context['message'] = t('Unknown error: Failed to %action %pid.', 
-            array(
-              '%pid' => $islandora_batch_object->id,
-              '%action' => $islandora_batch_object->getRepositoryActionDescription()
-            ));
-        }
-      }
-      catch (Exception $e) {
-        // Backend exception happened...  Flag an error.
-        $object['state'] = ISLANDORA_BATCH_STATE__ERROR;
-        $context['message'] = t('Exception occured: Failed to %action %pid because of %message.',
-        array(
-          '%pid' => $islandora_batch_object->id,
-          '%action' => $islandora_batch_object->getRepositoryActionDescription(),
-          '%message' => $e->getMessage()
-        ));
-      }
-    }
-    else {
-      $context['message'] = t('%pid not ready for ingest.', array('%pid' => $islandora_batch_object->id));
-    }
+		        if ($actionresult_object) {
+		          $context['message'] = t('Successfully %action %pid.', 
+		            array(
+		              '%pid' => $actionresult_object->id,
+		              '%action' => $islandora_batch_object->getRepositoryActionDescription()
+		            ));
+		        }
+		        else {
+		          // Failed to process on backend...  Flag an error.
+		          $object['state'] = ISLANDORA_BATCH_STATE__ERROR;
+		          $context['message'] = t('Unknown error: Failed to %action %pid.', 
+		            array(
+		              '%pid' => $islandora_batch_object->id,
+		              '%action' => $islandora_batch_object->getRepositoryActionDescription()
+		            ));
+		        }
+		      }
+		      catch (Exception $e) {
+		        // Backend exception happened...  Flag an error.
+		        $object['state'] = ISLANDORA_BATCH_STATE__ERROR;
+		        $context['message'] = t('Exception occured: Failed to %action %pid because of %message.',
+		        array(
+		          '%pid' => $islandora_batch_object->id,
+		          '%action' => $islandora_batch_object->getRepositoryActionDescription(),
+		          '%message' => $e->getMessage()
+		        ));
+		      }
+		    }
+		    else {
+		      $context['message'] = t('%pid not ready for ingest.', array('%pid' => $islandora_batch_object->id));
+		    }
 
     // Update the info in the database.
     module_load_include('inc', 'islandora_batch', 'includes/db');

--- a/includes/ingest.batch.inc
+++ b/includes/ingest.batch.inc
@@ -417,39 +417,39 @@ function islandora_batch_process_results($results, $timeout, $lock_timeout, &$co
         }
 
 		// Push to backend.
-		        $actionresult_object = $islandora_batch_object->batchRepositoryAction();
-       
-		        if ($actionresult_object) {
-		          $context['message'] = t('Successfully %action %pid.', 
-		            array(
-		              '%pid' => $actionresult_object->id,
-		              '%action' => $islandora_batch_object->getRepositoryActionDescription()
-		            ));
-		        }
-		        else {
-		          // Failed to process on backend...  Flag an error.
-		          $object['state'] = ISLANDORA_BATCH_STATE__ERROR;
-		          $context['message'] = t('Unknown error: Failed to %action %pid.', 
-		            array(
-		              '%pid' => $islandora_batch_object->id,
-		              '%action' => $islandora_batch_object->getRepositoryActionDescription()
-		            ));
-		        }
-		      }
-		      catch (Exception $e) {
-		        // Backend exception happened...  Flag an error.
-		        $object['state'] = ISLANDORA_BATCH_STATE__ERROR;
-		        $context['message'] = t('Exception occured: Failed to %action %pid because of %message.',
-		        array(
-		          '%pid' => $islandora_batch_object->id,
-		          '%action' => $islandora_batch_object->getRepositoryActionDescription(),
-		          '%message' => $e->getMessage()
-		        ));
-		      }
-		    }
-		    else {
-		      $context['message'] = t('%pid not ready for ingest.', array('%pid' => $islandora_batch_object->id));
-		    }
+        $actionresult_object = $islandora_batch_object->batchRepositoryAction();
+
+        if ($actionresult_object) {
+          $context['message'] = t('Successfully %action %pid.', 
+            array(
+              '%pid' => $actionresult_object->id,
+              '%action' => $islandora_batch_object->getRepositoryActionDescription()
+            ));
+        }
+        else {
+          // Failed to process on backend...  Flag an error.
+          $object['state'] = ISLANDORA_BATCH_STATE__ERROR;
+          $context['message'] = t('Unknown error: Failed to %action %pid.', 
+            array(
+              '%pid' => $islandora_batch_object->id,
+              '%action' => $islandora_batch_object->getRepositoryActionDescription()
+            ));
+        }
+      }
+      catch (Exception $e) {
+        // Backend exception happened...  Flag an error.
+        $object['state'] = ISLANDORA_BATCH_STATE__ERROR;
+        $context['message'] = t('Exception occured: Failed to %action %pid because of %message.',
+        array(
+          '%pid' => $islandora_batch_object->id,
+          '%action' => $islandora_batch_object->getRepositoryActionDescription(),
+          '%message' => $e->getMessage()
+        ));
+      }
+    }
+    else {
+      $context['message'] = t('%pid not ready for ingest.', array('%pid' => $islandora_batch_object->id));
+    }
 
     // Update the info in the database.
     module_load_include('inc', 'islandora_batch', 'includes/db');

--- a/includes/ingest.batch.inc
+++ b/includes/ingest.batch.inc
@@ -397,11 +397,11 @@ function islandora_batch_process_results($results, $timeout, $lock_timeout, &$co
   ) {
     $start = timer_read(ISLANDORA_BATCH_TIMER_NAME);
     // Process a single object.
-    $ingest_object = unserialize($object['data']);
+    $islandora_batch_object = unserialize($object['data']);
 
     if ($object['state'] !== ISLANDORA_BATCH_STATE__DONE) {
       // Both a simple state and state with message return are accepted.
-      $process_results = $ingest_object->batchProcess();
+      $process_results = $islandora_batch_object->batchProcess();
       $object['state'] = is_array($process_results) ? $process_results['state'] : $process_results;
     }
 
@@ -410,31 +410,53 @@ function islandora_batch_process_results($results, $timeout, $lock_timeout, &$co
         // XXX: Due to how the things currently work, the user name and
         // password hash gets serialized, so later changes to the password
         // can break things... Let's set the password again.
-        $username = $ingest_object->repository->api->connection->username;
+        $username = $islandora_batch_object->repository->api->connection->username;
         $user = user_load_by_name($username);
-        if ($ingest_object->repository->api->connection->password != $user->pass) {
-          $ingest_object->repository->api->connection->password = $user->pass;
+        if ($islandora_batch_object->repository->api->connection->password != $user->pass) {
+          $islandora_batch_object->repository->api->connection->password = $user->pass;
         }
 
         // Push to backend.
+<<<<<<< HEAD
         $ingested_object = islandora_add_object($ingest_object);
         if ($ingested_object) {
           $context['message'] = t('Ingested %pid.', array('%pid' => $ingested_object->id));
+=======
+        $actionresult_object = $islandora_batch_object->batchRepositoryAction();
+       
+        if ($actionresult_object) {
+          $object['data'] = serialize($actionresult_object);
+          $context['message'] = t('Successfully %action %pid.', 
+            array(
+              '%pid' => $actionresult_object->id,
+              '%action' => $islandora_batch_object->getRepositoryActionDescription
+            ));
+>>>>>>> First steps on abstract the repository action
         }
         else {
-          // Failed to ingest...  Flag an error.
+          // Failed to process on backend...  Flag an error.
           $object['state'] = ISLANDORA_BATCH_STATE__ERROR;
-          $context['message'] = t('Unknown error: Failed to ingest %pid.', array('%pid' => $ingest_object->id));
+          $context['message'] = t('Unknown error: Failed to %action %pid.', 
+            array(
+              '%pid' => $islandora_batch_object->id,
+              '%action' => $islandora_batch_object->getRepositoryActionDescription
+            ));
         }
       }
       catch (Exception $e) {
-        // Failed to ingest...  Flag an error.
+        // Backend exception happened...  Flag an error.
         $object['state'] = ISLANDORA_BATCH_STATE__ERROR;
-        $context['message'] = t('Exception occured: Failed to ingest %pid.', array('%pid' => $ingest_object->id));
+        $context['message'] = t('Exception occured: Failed to %action %pid because of %message.',
+        array(
+          '%pid' => $islandora_batch_object->id,
+          '%action' => $islandora_batch_object->getRepositoryActionDescription,
+          '%message' => $e->getMessage()
+        ));
+        
       }
     }
     else {
-      $context['message'] = t('%pid not ready for ingest.', array('%pid' => $ingest_object->id));
+      $context['message'] = t('%pid not ready for ingest.', array('%pid' => $islandora_batch_object->id));
     }
 
     // Update the info in the database.
@@ -450,7 +472,7 @@ function islandora_batch_process_results($results, $timeout, $lock_timeout, &$co
     );
 
     // Pass hook object and a pass/fail state for the object.
-    module_invoke_all(ISLANDORA_BATCH_OBJECT_PROCESSED_HOOK, $ingest_object, ($object['state'] === ISLANDORA_BATCH_STATE__DONE ? 1 : 0));
+    module_invoke_all(ISLANDORA_BATCH_OBJECT_PROCESSED_HOOK, $islandora_batch_object, ($object['state'] === ISLANDORA_BATCH_STATE__DONE ? 1 : 0));
 
     $end = timer_read(ISLANDORA_BATCH_TIMER_NAME);
     if (!isset($context['results']['count'])) {

--- a/includes/ingest.batch.inc
+++ b/includes/ingest.batch.inc
@@ -451,7 +451,6 @@ function islandora_batch_process_results($results, $timeout, $lock_timeout, &$co
           '%action' => $islandora_batch_object->getRepositoryActionDescription(),
           '%message' => $e->getMessage()
         ));
-        
       }
     }
     else {

--- a/includes/ingest.batch.inc
+++ b/includes/ingest.batch.inc
@@ -416,7 +416,7 @@ function islandora_batch_process_results($results, $timeout, $lock_timeout, &$co
           $islandora_batch_object->repository->api->connection->password = $user->pass;
         }
 
-		// Push to backend.
+        // Push to backend.
         $actionresult_object = $islandora_batch_object->batchRepositoryAction();
 
         if ($actionresult_object) {

--- a/includes/ingest.batch.inc
+++ b/includes/ingest.batch.inc
@@ -19,7 +19,7 @@ define('ISLANDORA_BATCH_EMPTY_SET', 2);
  * Function to get the average.
  *
  * @param array $context
- *   The context
+ *   The context.
  */
 function islandora_batch_get_average($context) {
   if ($context['results']['count'] > 0) {
@@ -39,7 +39,7 @@ function islandora_batch_ingest_preprocess($preprocessor, &$context) {
 /**
  * Get the name of the lock to acquire/release.
  *
- * @param string|int|NULL $ingest_set
+ * @param string|int|null $ingest_set
  *   A string or integer identifying an ingest set to process. NULL indicates
  *   that it is a general/set-independent batch, processing everything in the
  *   queue.
@@ -91,7 +91,7 @@ function islandora_batch_get_lock_timeout($timeout) {
  * The general/set-independent batch should not be able to run at the same time
  * as any other batch.
  *
- * @param string|int|NULL $ingest_set
+ * @param string|int|null $ingest_set
  *   A string or integer identifying an ingest set to process. NULL indicates
  *   that it is a general/set-independent batch, processing everything in the
  *   queue.
@@ -373,7 +373,6 @@ function test_islandora_batch_process_results($results, $timeout, $lock_timeout,
   return TRUE;
 }
 
-
 /**
  * Process set of result from the islandora_batch_queue table.
  *
@@ -420,19 +419,19 @@ function islandora_batch_process_results($results, $timeout, $lock_timeout, &$co
         $actionresult_object = $islandora_batch_object->batchRepositoryAction();
 
         if ($actionresult_object) {
-          $context['message'] = t('Successfully %action %pid.', 
+          $context['message'] = t('Successfully %action %pid.',
             array(
               '%pid' => $actionresult_object->id,
-              '%action' => $islandora_batch_object->getRepositoryActionDescription()
+              '%action' => $islandora_batch_object->getRepositoryActionDescription(),
             ));
         }
         else {
           // Failed to process on backend...  Flag an error.
           $object['state'] = ISLANDORA_BATCH_STATE__ERROR;
-          $context['message'] = t('Unknown error: Failed to %action %pid.', 
+          $context['message'] = t('Unknown error: Failed to %action %pid.',
             array(
               '%pid' => $islandora_batch_object->id,
-              '%action' => $islandora_batch_object->getRepositoryActionDescription()
+              '%action' => $islandora_batch_object->getRepositoryActionDescription(),
             ));
         }
       }
@@ -443,7 +442,7 @@ function islandora_batch_process_results($results, $timeout, $lock_timeout, &$co
         array(
           '%pid' => $islandora_batch_object->id,
           '%action' => $islandora_batch_object->getRepositoryActionDescription(),
-          '%message' => $e->getMessage()
+          '%message' => $e->getMessage(),
         ));
       }
     }

--- a/includes/islandora_batch_object_base.inc
+++ b/includes/islandora_batch_object_base.inc
@@ -8,9 +8,10 @@
 /**
  * Batch interface.
  *
- * Implementing classes should subclass some version of FedoraObject, so
+ * Implementing classes should subclass some version of FedoraObject, so.
  */
 abstract class IslandoraBatchObject extends IslandoraNewFedoraObject {
+
   /**
    * The initial batch state.
    *
@@ -40,8 +41,7 @@ abstract class IslandoraBatchObject extends IslandoraNewFedoraObject {
    *     state or containing more information.
    */
   abstract public function batchProcess();
-  
- 
+
   /**
    * Get the resources to which we should link in the database.
    *
@@ -72,7 +72,6 @@ abstract class IslandoraBatchObject extends IslandoraNewFedoraObject {
    */
   abstract public function addRelationships();
 
-  
   /**
    * The actual back-end action that is run after the batchProcess.
    *
@@ -89,14 +88,13 @@ abstract class IslandoraBatchObject extends IslandoraNewFedoraObject {
     else {
       return FALSE;
     }
-      
   }
 
   /**
    * A human readable short description of the repository action.
-   *  Recomended is a verb in past tense.
-   *  
+   *
    * @return string
+   *   Recomended value is a verb in past tense.
    */
   public function getRepositoryActionDescription() {
     return "ingested";
@@ -123,6 +121,10 @@ abstract class IslandoraBatchObject extends IslandoraNewFedoraObject {
       )));
     }
   }
+
 }
 
+/**
+ * An Islandora Batch Exception Class.
+ */
 class IslandoraBatchNoIdException extends Exception {}

--- a/includes/islandora_batch_object_base.inc
+++ b/includes/islandora_batch_object_base.inc
@@ -76,27 +76,32 @@ abstract class IslandoraBatchObject extends IslandoraNewFedoraObject {
   /**
    * The actual back-end action that is run after the batchProcess.
    *
-   * By default Classes not overriding this will get objects pushed to the back-end.
+   * Classes not overriding this will get objects pushed to the back-end.
    * (ingested)
    *
-   * @return AbstractObject
+   * @return AbstractObject|false
+   *   Either a newly ingested Abstract Object or false if failed.
    */
   public function batchRepositoryAction() {
-    return islandora_add_object($this);
-    // need to define a wording for this like "ingest", "update, etc" This needs to return
-    // an Array full of little funny data
+    if (!islandora_object_load($this->id)) {
+      return islandora_add_object($this);
+    }
+    else {
+      return FALSE;
+    }
+      
   }
+
   /**
    * A human readable short description of the repository action.
    *  Recomended is a verb in past tense.
    *  
    * @return string
-   
    */
   public function getRepositoryActionDescription() {
     return "ingested";
   }
-  
+
   /**
    * Get the ID of this object in the queue.
    *

--- a/includes/islandora_batch_object_base.inc
+++ b/includes/islandora_batch_object_base.inc
@@ -93,7 +93,7 @@ abstract class IslandoraBatchObject extends IslandoraNewFedoraObject {
    * @return string
    
    */
-  public getRepositoryActionDescription() {
+  public function getRepositoryActionDescription() {
     return "ingested";
   }
   

--- a/includes/islandora_batch_object_base.inc
+++ b/includes/islandora_batch_object_base.inc
@@ -40,7 +40,8 @@ abstract class IslandoraBatchObject extends IslandoraNewFedoraObject {
    *     state or containing more information.
    */
   abstract public function batchProcess();
-
+  
+ 
   /**
    * Get the resources to which we should link in the database.
    *
@@ -71,6 +72,31 @@ abstract class IslandoraBatchObject extends IslandoraNewFedoraObject {
    */
   abstract public function addRelationships();
 
+  
+  /**
+   * The actual back-end action that is run after the batchProcess.
+   *
+   * By default Classes not overriding this will get objects pushed to the back-end.
+   * (ingested)
+   *
+   * @return AbstractObject
+   */
+  public function batchRepositoryAction() {
+    return islandora_add_object($this);
+    // need to define a wording for this like "ingest", "update, etc" This needs to return
+    // an Array full of little funny data
+  }
+  /**
+   * A human readable short description of the repository action.
+   *  Recomended is a verb in past tense.
+   *  
+   * @return string
+   
+   */
+  public getRepositoryActionDescription() {
+    return "ingested";
+  }
+  
   /**
    * Get the ID of this object in the queue.
    *

--- a/islandora_batch.install
+++ b/islandora_batch.install
@@ -45,7 +45,7 @@ function islandora_batch_schema() {
         'not null' => FALSE,
       ),
     ),
-    'primary key' => array('id'),
+    'primary key' => array('id', 'sid'),
     'indexes' => array(
       'parent_index' => array('parent'),
       'sid' => array('sid'),

--- a/islandora_batch.install
+++ b/islandora_batch.install
@@ -358,3 +358,12 @@ function islandora_batch_update_7104() {
     'not null' => FALSE,
   ));
 }
+
+
+/**
+ * Make PID and Set ID combined primary Key.
+ */
+function islandora_batch_update_7105() {
+  db_drop_primary_key('islandora_batch_queue');
+  db_add_primary_key('islandora_batch_queue', array('id', 'sid'));
+}

--- a/islandora_batch.install
+++ b/islandora_batch.install
@@ -359,7 +359,6 @@ function islandora_batch_update_7104() {
   ));
 }
 
-
 /**
  * Make PID and Set ID combined primary Key.
  */


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-2046)

# What does this Pull Request do?

Allows Islandora Batch to be used for other more repository actions (like delete or update) but keeps  "ingest" as default to allow any other extending class of IslandoraBatchObject to keep working as before. Also changes `islandora_batch_queue`primary index to a compound one, to allow same Islandora installation to keep same PID in different sets, but, still enforces uniqueness inside a single SET.

# What's new?
If you code a little, your Islandora Batch can now update, edit, drop, purge, clone or QA your objects. Up to you. If you don't code, all is still the same in Islandora paradise.
But: this opens a wide open world to reusing our batch queue for post-processing, editing, etc operations, including working on existing objects using pieces from newly created in-batch ones.
Also: this is  a first step, probably more can be done and will be done in the future.

# How should this be tested?

Please make sure that your existing Batch Sets and New ingests still work. Not much more?

Enjoy the flexibility.

Islandora IMI uses this patch already for its update capabilities. As you see implementation is quite simple. https://github.com/mnylc/islandora_multi_importer/blob/e674a8371efddeba7b4ca839697a69a5e3a1b29b/includes/islandora_multi_batch.inc#L624-L653

# Additional Notes:
* Does this change require documentation to be updated? No
* Does this change add any new dependencies?  No
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?  No
* Could this change impact execution of existing code? Nope. 

